### PR TITLE
fix: Fix migration name when using single quotes to escape

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: |
         npm install
         npm run all
-  test: # make sure the action works on a clean machine without building
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: ./
-      with: 
-        milliseconds: 1000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,9 @@ jobs:
     - run: |
         npm install
         npm run all
+
+  test: # make sure the action works on a clean machine without building
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./

--- a/__tests__/util/getMigrationName.test.ts
+++ b/__tests__/util/getMigrationName.test.ts
@@ -9,3 +9,8 @@ test('gets filename when passed only filename with extension', () => {
   const input = getMigrationName('001_testing.py');
   expect(input).toBe('001_testing');
 });
+
+test('preserve single quotes (e.g. if used to escape)', () => {
+  const input = getMigrationName(`'foo/bar/001_testing.py'`);
+  expect(input).toBe(`'001_testing'`);
+});

--- a/action.yml
+++ b/action.yml
@@ -3,13 +3,18 @@ description: 'Actions related to django migrations in sentry'
 author: 'sentry.io'
 inputs:
   cmd:
+    required: false
     description: "The command to run to generate SQL"
     default: "sentry django sqlmigrate sentry"
   run:
+    required: false
     description: 'Action for the action to take. Possible values: null, "placeholder"'
   migration:
+    required: true
     description: 'file name (or number) for the migration'
   githubToken:
+    required: false
+    default: '${{ github.token }}'
     description: 'GitHub Token (available as `secrets.GITHUB_TOKEN`)'
 runs:
   using: 'node12'

--- a/src/util/getMigrationName.ts
+++ b/src/util/getMigrationName.ts
@@ -1,7 +1,16 @@
 export function getMigrationName(name: string): string {
-  return name
-    .trim()
+  const pathRegex = /([']?)(.*?)([']?)$/;
+
+  const matches = name.trim().match(pathRegex);
+
+  if (!matches) {
+    return '';
+  }
+
+  const [, startQuote, path, endQuote] = matches;
+
+  return `${startQuote}${path
     .split('/')
     .slice(-1)[0]
-    .replace('.py', '');
+    .replace('.py', '')}${endQuote}`;
 }


### PR DESCRIPTION
This preserves single quotes when used to escape a file name (e.g. when using the [`paths-filter` action](https://github.com/dorny/paths-filter))