### PR TITLE
fix: Still include commentIntro

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -129,7 +129,11 @@ function run() {
                 core.debug(output);
                 let body;
                 if (useRawBody == 'true') {
-                    body = output.trim();
+                    // commentIntro needs to be present in body so that the bot edits
+                    // existing comments and doesn't create new ones.
+                    body = `<!-- ${commentIntro} -->
+        ${output.trim()}
+        `.trim();
                 }
                 else {
                     body = `${commentIntro}

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,8 +108,7 @@ async function run(): Promise<void> {
         // commentIntro needs to be present in body so that the bot edits
         // existing comments and doesn't create new ones.
         body = `<!-- ${commentIntro} -->
-        ${output.trim()}
-        `.trim();
+        ${output.trim()}`
       } else {
         body = `${commentIntro}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,11 @@ async function run(): Promise<void> {
 
       let body;
       if (useRawBody == 'true') {
-        body = output.trim();
+        // commentIntro needs to be present in body so that the bot edits
+        // existing comments and doesn't create new ones.
+        body = `<!-- ${commentIntro} -->
+        ${output.trim()}
+        `.trim();
       } else {
         body = `${commentIntro}
 


### PR DESCRIPTION
Without this string being present in the comment, the bot will keep
posting new comments instead of editing existing ones.

Sorry for the noise.