### PR TITLE
fix: Additional indentation destroys markdown output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -132,8 +132,7 @@ function run() {
                     // commentIntro needs to be present in body so that the bot edits
                     // existing comments and doesn't create new ones.
                     body = `<!-- ${commentIntro} -->
-        ${output.trim()}
-        `.trim();
+${output}`;
                 }
                 else {
                     body = `${commentIntro}

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,7 +108,7 @@ async function run(): Promise<void> {
         // commentIntro needs to be present in body so that the bot edits
         // existing comments and doesn't create new ones.
         body = `<!-- ${commentIntro} -->
-        ${output.trim()}`
+${output}`;
       } else {
         body = `${commentIntro}
 


### PR DESCRIPTION
This trim() wasn't really thoughtfully considered by me. It makes it
impossible to just print a newline to work around the extra whitespace,
and it makes it harder to start the output with a codeblock. Just get
rid of it.
